### PR TITLE
Possible bug when setting a BOOLEAN attribute to false

### DIFF
--- a/lib/treequel/directory.rb
+++ b/lib/treequel/directory.rb
@@ -50,7 +50,9 @@ class Treequel::Directory
 	# See #add_object_conversion for more information on what a valid conversion is.
 	DEFAULT_OBJECT_CONVERSIONS = {
 		OIDS::BIT_STRING_SYNTAX         => lambda {|bs, _| bs.to_i.to_s(2) },
-		OIDS::BOOLEAN_SYNTAX            => lambda {|obj, _| obj ? 'TRUE' : 'FALSE' },
+		# This is the obj returned by Model#[]=
+		# IS BOOLEAN, so if the user does not specified FALSE, we make it true
+		OIDS::BOOLEAN_SYNTAX            => lambda {|obj, _| obj == "FALSE" ? "FALSE" : "TRUE" }
 		OIDS::GENERALIZED_TIME_SYNTAX   => lambda {|time, _| time.ldap_generalized },
 		OIDS::UTC_TIME_SYNTAX           => lambda {|time, _| time.ldap_utc },
 		OIDS::INTEGER_SYNTAX            => lambda {|obj, _| Integer(obj).to_s },

--- a/lib/treequel/directory.rb
+++ b/lib/treequel/directory.rb
@@ -52,7 +52,7 @@ class Treequel::Directory
 		OIDS::BIT_STRING_SYNTAX         => lambda {|bs, _| bs.to_i.to_s(2) },
 		# This is the obj returned by Model#[]=
 		# IS BOOLEAN, so if the user does not specified FALSE, we make it true
-		OIDS::BOOLEAN_SYNTAX            => lambda {|obj, _| obj == "FALSE" ? "FALSE" : "TRUE" }
+		OIDS::BOOLEAN_SYNTAX            => lambda {|obj, _| obj == "FALSE" ? "FALSE" : "TRUE" },
 		OIDS::GENERALIZED_TIME_SYNTAX   => lambda {|time, _| time.ldap_generalized },
 		OIDS::UTC_TIME_SYNTAX           => lambda {|time, _| time.ldap_utc },
 		OIDS::INTEGER_SYNTAX            => lambda {|obj, _| Integer(obj).to_s },

--- a/lib/treequel/model.rb
+++ b/lib/treequel/model.rb
@@ -270,7 +270,13 @@ class Treequel::Model < Treequel::Branch
 		value = Array( value ) unless attrtype.single?
 
 		self.mark_dirty
+		# This was skipped every time the attribute was BOOLEAN and
+		# the value was false
 		if value
+			@values[ attrtype.name.to_sym ] = value
+		# We chech if the user is passing false, because is 
+		# setting a BOOLEAN attribute
+		elsif value.class == FalseClass
 			@values[ attrtype.name.to_sym ] = value
 		else
 			@values.delete( attrtype.name.to_sym )

--- a/lib/treequel/model/schemavalidations.rb
+++ b/lib/treequel/model/schemavalidations.rb
@@ -41,7 +41,12 @@ module Treequel::Model::SchemaValidations
 		self.must_attribute_types.each do |attrtype|
 			oid = attrtype.name
 			if attrtype.single?
-				self.errors.add( oid, "MUST have a value" ) unless self[ oid ]
+				# We do not add an error if the attribute is a Boolean and the value is FALSE 
+				if attrtype.syntax_oid == Treequel::OIDS::BOOLEAN_SYNTAX
+					self.errors.add( oid, "MUST have a value" ) unless self[ oid ] || self[ oid ].class == FalseClass
+				else
+					self.errors.add( oid, "MUST have a value" ) unless self[ oid ]
+				end
 			else
 				self.errors.add( oid, "MUST have at least one value" ) if self[ oid ].empty?
 			end


### PR DESCRIPTION
Using the "object.attribute=false" setter always saved the attribute as TRUE.
This was because the code was checking for the value in the following way

``` ruby
if value
  @values[ attrtype.name.to_sym ] = value
else
  @values.delete( attrtype.name.to_sym )
end
```

Also i made a really lazy modification on Treequel::Directory. I did not want to dig any further because i want to confirm the bug first.
